### PR TITLE
Fix landing page layout for correct flow

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -36,10 +36,7 @@ export default function RootLayout({
   return (
     <>
       <Header />
-      <main className="flex h-[calc(100svh-4rem)] flex-col items-center justify-center bg-blue-50/40 p-10 mx-auto">
-        {children}
-      </main>
-
+      {children}
     </>
   );
 }


### PR DESCRIPTION
Remove `<main>` wrapper from home layout to match rutugo.com's landing page structure.

The previous `<main>` wrapper in `app/(home)/layout.tsx` was applying conflicting flex, centering, padding, and background styles, which disrupted the landing page's intended full-bleed and dynamic layout. Removing it allows the page to control its own layout, aligning with the reference site.

---

[Open in Web](https://cursor.com/agents?id=bc-0a11f6da-b2ff-4ef2-871b-9a5fc7495ba9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0a11f6da-b2ff-4ef2-871b-9a5fc7495ba9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)